### PR TITLE
changes: 'httphost' option added for localhost binding

### DIFF
--- a/aceconfig.py
+++ b/aceconfig.py
@@ -70,6 +70,8 @@ class AceConfig(acedefconfig.AceDefConfig):
     # HTTP AceProxy configuration
     # ----------------------------------------------------
     #
+    # Bind host. '' - autodetect, 0.0.0.0 - listen on all addresses, change to whatever IP you want to listen on this IP only
+    httphost = ''
     # HTTP Server port
     httpport = 8000
     # If started as root, drop privileges to this user.
@@ -116,9 +118,9 @@ class AceConfig(acedefconfig.AceDefConfig):
     #
     # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
     loglevel = logging.DEBUG
-    # Log message forma
+    # Log message format
     logfmt = '%(filename)-20s [LINE:%(lineno)-4s]# %(levelname)-8s [%(asctime)s]  %(message)s'
-    # Log date forma
+    # Log date format
     logdatefmt='%d.%m %H:%M:%S'
     # Full path to a log file
     # For Windows OS something like that logfile = "c:\\Python27\\log_AceHttp.txt"

--- a/acehttp.py
+++ b/acehttp.py
@@ -433,8 +433,8 @@ if AceConfig.acespawn or AceConfig.transcode: DEVNULL = open(os.devnull, 'wb')
 logger.info('Ace Stream HTTP Proxy server on Python %s starting .....' % sys.version.split()[0])
 
 #### Initial settings for AceHTTPproxy host IP
-if AceConfig.httphost == '0.0.0.0':
-    AceConfig.httphost = [(s.connect(('1.1.1.1', 53)), s.getsockname()[0], s.close()) for s in [socket(AF_INET, SOCK_DGRAM)]][0][1]
+if AceConfig.httphost == '':
+    AceConfig.httphost = [(s.connect(('1.1.1.1', 80)), s.getsockname()[0], s.close()) for s in [socket(AF_INET, SOCK_DGRAM)]][0][1]
     logger.debug('Ace Stream HTTP Proxy server IP: %s autodetected' % AceConfig.httphost)
 # Check whether we can bind to the defined port safely
 if AceConfig.osplatform != 'Windows' and os.getuid() != 0 and AceConfig.httpport <= 1024:

--- a/plugins/torrentfilms_plugin.py
+++ b/plugins/torrentfilms_plugin.py
@@ -79,6 +79,14 @@ class Torrentfilms(AceProxyPlugin):
 
     def createPlaylist(self, hostport, reqtype, fmt):
 
+        localhost_list = ['localhost', '127.0.0.1', '0.0.0.0']
+        acehost = AceConfig.acehostslist[0][0] if not AceConfig.acehost else AceConfig.acehost
+        aceport = AceConfig.acehostslist[0][2] if not AceConfig.aceHTTPport else AceConfig.aceHTTPport
+        hostaddr = hostport.replace(':' + str(AceConfig.httpport), "")
+
+        #For local AceStream engine use hostadrr from 'hostport'.
+        if acehost in localhost_list: acehost = hostaddr
+
         if config.updateevery == 0: self.playlistdata()
         ln = '#EXTM3U deinterlace=1 m3uautoload=1 cache=1000\n'
         for data in self.playlist:
@@ -93,8 +101,7 @@ class Torrentfilms(AceProxyPlugin):
                  else: ln += '/stream.mp4\n'
              else:
                   ln += 'http://%s:%s/ace/%s?infohash=%s&transcode_audio=%s&transcode_mp3=%s&transcode_ac3=%s&preferred_audio_language=%s&_idx=%s\n' % \
-                        (AceConfig.acehostslist[0][0] if not AceConfig.acehost else AceConfig.acehost ,
-                         AceConfig.acehostslist[0][2] if not AceConfig.aceHTTPport else AceConfig.aceHTTPport,
+                        (acehost, aceport,
                          config.streamtype, infohash,AceConfig.transcode_audio, AceConfig.transcode_mp3,
                          AceConfig.transcode_ac3, AceConfig.preferred_audio_language, key)
 


### PR DESCRIPTION
Hello,

Here my changes for review:
1) users can use httphost = '0.0.0.0' binding option for localhost support. 'autodetect' mode (current master branch) can be used by default with empty httphost = ''
2) torrentfilms plugin generate correct url for local AceStream engine in m3u-playlist 