### PR TITLE
geoip-db.com moves to geolocation-db.com

### DIFF
--- a/plugins/stat_plugin.py
+++ b/plugins/stat_plugin.py
@@ -120,7 +120,7 @@ class Stat(object):
                else:
                   try:
                      headers = {'User-Agent': 'API Browser'}
-                     with requests.get('https://geoip-db.com/jsonp/%s' % c.clientip, headers=headers, stream=False, timeout=5) as r:
+                     with requests.get('https://geolocation-db.com/jsonp/%s' % c.clientip, headers=headers, stream=False, timeout=5) as r:
                         if r.encoding is None: r.encoding = 'utf-8'
                         c.clientDetail = json.loads(r.text.split('(', 1)[1].strip(')'))
                         c.clientDetail['vendor'] = ''


### PR DESCRIPTION
Due to an infringement claim of Maxmind.com, we are no longer allowed to use the protected trademark 'geoip' in any of our products, including our domain name. Because our domain name contains geoip, we are forced to move our services to another url, geolocation-db.com